### PR TITLE
Simplify error reporting by relying on t.Helper()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,10 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'feature/**'
+      - 'fix/**'
   pull_request:
     branches: [ main ]
 

--- a/assert.go
+++ b/assert.go
@@ -95,7 +95,7 @@ func NotNil(t testing.TB, value any) {
 	t.Helper()
 
 	if isNil(value) {
-		t.Errorf("\n%s\nexpected value to not be nil", location())
+		t.Error("\nexpected value to not be nil")
 	}
 }
 
@@ -110,7 +110,7 @@ func Panics(t testing.TB, fn func(), expectedMsg string) {
 				failCompare(t, expectedMsg, actualMsg, "unexpected panic message")
 			}
 		} else {
-			t.Errorf("\n%s\nExpected panic: %v\n  Actual: no panic", location(), expectedMsg)
+			t.Errorf("\nExpected panic: %v\n  Actual: no panic", expectedMsg)
 		}
 	}()
 

--- a/assert_test.go
+++ b/assert_test.go
@@ -194,8 +194,8 @@ func TestErrorAs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := NewTestRecorder(t)
-
 			var target *testError
+
 			ErrorAs(rec, tt.err, &target)
 
 			if tt.wantError != rec.HasError() {

--- a/collection.go
+++ b/collection.go
@@ -41,7 +41,7 @@ func Empty(t testing.TB, collection any, msg ...string) {
 			)
 		}
 	default:
-		t.Errorf("\n%s\nEmpty called with unsupported type: %T", location(), collection)
+		t.Errorf("\nEmpty() called with unsupported type: (%T)", collection)
 	}
 }
 
@@ -88,7 +88,7 @@ func Len(t testing.TB, collection any, expected int) {
 			failCompare(t, expected, v.Len(), "unexpected length")
 		}
 	default:
-		t.Errorf("\n%s\nLen called with unsupported type: %T", location(), collection)
+		t.Errorf("\nLen called with unsupported type: %T", collection)
 	}
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -5,9 +5,7 @@ package assert
 
 import (
 	"fmt"
-	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -79,18 +77,17 @@ func failCompare[T any](t testing.TB, actual, expected T, msg ...string) {
 	t.Helper()
 
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("\n%s\n", location()))
 
 	if len(msg) > 0 && msg[0] != "" {
-		builder.WriteString(fmt.Sprintf("Message: %s\n", msg[0]))
+		builder.WriteString(fmt.Sprintf("\n Message: %s", msg[0]))
 	}
 
 	// Get the types of both values for more informative error messages
 	exptectedType := reflect.TypeOf(actual)
 	actualType := reflect.TypeOf(expected)
 
-	// Build the error message
-	builder.WriteString(fmt.Sprintf("Expected: (%v) %#v\n", exptectedType, expected))
+	// Build the error messageyy
+	builder.WriteString(fmt.Sprintf("\nExpected: (%v) %#v\n", exptectedType, expected))
 	builder.WriteString(fmt.Sprintf("  Actual: (%v) %#v\n", actualType, actual))
 
 	t.Error(builder.String())
@@ -120,26 +117,4 @@ func isNil(value any) bool {
 	default:
 		return false
 	}
-}
-
-// callerFunc defines a function type that matches runtime.Caller signature.
-// This abstraction allows us to inject different caller behaviors for testing.
-type callerFunc func(skip int) (pc uintptr, file string, line int, ok bool)
-
-// locationWith returns a formatted string indicating the source file and line number
-// using a provided caller function. This allows for testing the error path
-// by injecting a mock caller function.
-func locationWith(f callerFunc) string {
-	_, file, line, ok := f(2)
-	if !ok {
-		return "unknown location"
-	}
-	return fmt.Sprintf("%s:%d", filepath.Base(file), line)
-}
-
-// location returns a formatted string indicating the source file and line number
-// where this function was called. It uses runtime.Caller internally to retrieve
-// this information.
-func location() string {
-	return locationWith(runtime.Caller)
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,7 +4,6 @@
 package assert
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 )
@@ -45,8 +44,7 @@ func TestCompare(t *testing.T) {
 
 		for _, part := range expectedParts {
 			if !strings.Contains(errorMsg, part) {
-				t.Errorf("incorrect error message\nwant: %q\nin: %q",
-					part, errorMsg)
+				t.Errorf("incorrect error message\nwant: %q\nin: %q", part, errorMsg)
 			}
 		}
 	})
@@ -96,24 +94,19 @@ func TestFailCompare(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recorder := NewTestRecorder(t)
+			rec := NewTestRecorder(t)
 
-			failCompare(recorder, tt.actual, tt.expected, tt.msg...)
+			failCompare(rec, tt.actual, tt.expected, tt.msg...)
 
-			if !recorder.HasError() {
+			if !rec.HasError() {
 				t.Error("failCompare() did not record error")
 			}
 
-			errorMsg := recorder.ErrorMessage()
-
-			if !strings.Contains(errorMsg, ".go:") {
-				t.Error("failCompare() message missing file location")
-			}
+			errorMsg := rec.ErrorMessage()
 
 			for _, part := range tt.wantParts {
 				if !strings.Contains(errorMsg, part) {
-					t.Errorf("failCompare() message missing %q\ngot: %s",
-						part, errorMsg)
+					t.Errorf("failCompare() message missing %q\ngot: %s", part, errorMsg)
 				}
 			}
 		})
@@ -246,29 +239,4 @@ func TestIsNil(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestLocation(t *testing.T) {
-	t.Run("normal case", func(t *testing.T) {
-		loc := location()
-		matched, err := regexp.MatchString(`\w+\.go:\d+`, loc)
-		if err != nil {
-			t.Fatalf("regex match failed: %v", err)
-		}
-		if !matched {
-			t.Errorf("location() = %v, want pattern file.go:line", loc)
-		}
-	})
-
-	t.Run("caller not available", func(t *testing.T) {
-		// Mock function qui simule l'échec de runtime.Caller
-		mockCaller := func(skip int) (pc uintptr, file string, line int, ok bool) {
-			return 0, "", 0, false
-		}
-
-		result := locationWith(mockCaller)
-		if result != "unknown location" {
-			t.Errorf("locationWith(mockCaller) = %v, want 'unknown location'", result)
-		}
-	})
 }


### PR DESCRIPTION
This PR simplifies our error reporting mechanism by fully leveraging Go's native `t.Helper()` functionality.

Key improvements:
- Removed custom `location` function and related utilities
- Let Go handle error location reporting natively through `t.Helper()`
- Improved error message formatting and consistency
- Unified variable naming conventions in tests (using 'rec' consistently)
- Added GitHub Actions support for feature branches

This change makes our code:
- More idiomatic by using Go's built-in testing features
- Simpler to maintain with less custom code
- More reliable as it uses proven Go testing mechanics